### PR TITLE
perf: replace recursive file tree with flat directory cache (Explorer model)

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -3537,6 +3537,55 @@ async fn copy_file(src: String, dest: String) -> Result<(), String> {
         .map_err(|e| format!("Cannot copy file: {}", e))
 }
 
+/// Search files recursively, matching filenames case-insensitively against query.
+/// Returns a flat list of matching FileNode entries.
+#[tauri::command]
+async fn search_files(root: String, query: String) -> Result<Vec<FileNode>, String> {
+    let root_path = std::path::Path::new(&root);
+    if !root_path.exists() {
+        return Err("Directory does not exist".into());
+    }
+    let query_lower = query.to_lowercase();
+
+    const IGNORED_DIRS: &[&str] = &[
+        "node_modules", "target", "__pycache__", ".git", ".DS_Store", "Thumbs.db",
+        ".venv", "venv", ".env", "dist", "build", ".next", ".nuxt", ".parcel-cache",
+        "coverage", ".turbo", ".svelte-kit", ".claude", "AppData", ".cache",
+    ];
+
+    fn walk(dir: &std::path::Path, query: &str) -> Vec<FileNode> {
+        let mut results = vec![];
+        let entries = match std::fs::read_dir(dir) {
+            Ok(e) => e,
+            Err(_) => return results,
+        };
+        for entry in entries.flatten() {
+            let name = entry.file_name().to_string_lossy().to_string();
+            if IGNORED_DIRS.iter().any(|seg| name == *seg) {
+                continue;
+            }
+            let path = entry.path();
+            let is_dir = path.is_dir();
+            let name_lower = name.to_lowercase();
+            if name_lower.contains(query) {
+                let children = if is_dir { Some(vec![]) } else { None };
+                results.push(FileNode {
+                    name: name.clone(),
+                    path: path.to_string_lossy().to_string(),
+                    is_dir,
+                    children,
+                });
+            }
+            if is_dir {
+                results.extend(walk(&path, query));
+            }
+        }
+        results
+    }
+
+    Ok(walk(root_path, &query_lower))
+}
+
 #[tauri::command]
 async fn rename_file(src: String, dest: String) -> Result<(), String> {
     reject_unsafe_path(&src)?;
@@ -3764,6 +3813,8 @@ async fn watch_directory(
         "target",
         "__pycache__",
         ".venv",
+        "AppData",
+        ".cache",
     ];
 
     let mut watcher = notify::recommended_watcher(move |res: Result<Event, notify::Error>| {
@@ -7961,6 +8012,7 @@ pub fn run() {
             list_recent_projects,
             watch_directory,
             unwatch_directory,
+            search_files,
             save_temp_file,
             get_file_size,
             check_file_access,

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -135,7 +135,6 @@ function App() {
   const setLastSeenVersion = useSettingsStore((s) => s.setLastSeenVersion);
   const selectedSessionId = useSessionStore((s) => s.selectedSessionId);
   const loadTree = useFileStore((s) => s.loadTree);
-  const refreshTree = useFileStore((s) => s.refreshTree);
   const markFileChanged = useFileStore((s) => s.markFileChanged);
   const prevDirRef = useRef<string | null>(null);
 
@@ -604,28 +603,34 @@ function App() {
     };
   }, [workingDirectory]);
 
-  // Listen for file change events from the watcher
-  // Debounce tree refresh for created/removed events (structure changes)
+  // Listen for file change events from the watcher.
+  // Only refresh expanded directories — unexpanded dirs load fresh on expand.
   const refreshTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   useEffect(() => {
     const unlisten = onFileChange((event) => {
-      // Defense-in-depth: skip paths under noisy directories (also filtered in Rust)
-      const filtered = event.paths.filter((p) =>
-        !/(^|[/\\])(\.(claude|git)|node_modules|__pycache__)[/\\]/.test(p)
-      );
-      if (filtered.length === 0) return;
-
-      for (const filePath of filtered) {
+      for (const filePath of event.paths) {
         markFileChanged(filePath, event.kind);
       }
 
-      // When files are created or removed, the tree structure changes —
-      // debounce a full tree reload (300ms to batch rapid changes)
+      // When files are created or removed, refresh only the expanded parent directories
       if (event.kind === 'created' || event.kind === 'removed') {
+        const { expandedDirs, refreshDir } = useFileStore.getState();
+        const toRefresh = new Set<string>();
+        for (const p of event.paths) {
+          const lastSep = Math.max(p.lastIndexOf('/'), p.lastIndexOf('\\'));
+          const parentDir = lastSep > 0 ? p.slice(0, lastSep) : p.slice(0, 1) || '/';
+          if (expandedDirs.has(parentDir)) {
+            toRefresh.add(parentDir);
+          }
+        }
+        if (toRefresh.size === 0) return;
+
         if (refreshTimerRef.current) clearTimeout(refreshTimerRef.current);
-        refreshTimerRef.current = setTimeout(() => {
-          refreshTree();
+        refreshTimerRef.current = setTimeout(async () => {
+          for (const dir of toRefresh) {
+            await refreshDir(dir);
+          }
           refreshTimerRef.current = null;
         }, 300);
       }
@@ -634,7 +639,7 @@ function App() {
       unlisten.then((fn) => fn());
       if (refreshTimerRef.current) clearTimeout(refreshTimerRef.current);
     };
-  }, [markFileChanged, refreshTree]);
+  }, [markFileChanged]);
 
   return (
     <>

--- a/src/components/files/FileExplorer.tsx
+++ b/src/components/files/FileExplorer.tsx
@@ -212,26 +212,6 @@ interface FlatMatch {
   relDir: string;
 }
 
-function collectMatches(nodes: FileNode[], query: string, rootPrefix: string): FlatMatch[] {
-  const results: FlatMatch[] = [];
-  function walk(node: FileNode) {
-    if (node.name.toLowerCase().includes(query)) {
-      // Compute relative directory (parent path minus root prefix)
-      const lastSep = node.path.lastIndexOf('/');
-      const parentPath = lastSep > 0 ? node.path.slice(0, lastSep) : '';
-      const relDir = parentPath.startsWith(rootPrefix)
-        ? parentPath.slice(rootPrefix.length).replace(/^\//, '')
-        : parentPath;
-      results.push({ node, relDir });
-    }
-    if (node.children) {
-      for (const child of node.children) walk(child);
-    }
-  }
-  for (const n of nodes) walk(n);
-  return results;
-}
-
 function SearchResultItem({
   match,
   onContextMenu,
@@ -308,9 +288,14 @@ function TreeNode({
   onCreateSubmit: () => void;
   onCreateCancel: () => void;
 }) {
-  const [expanded, setExpanded] = useState(false);
+  const isExpanded = useFileStore((s) => s.expandedDirs.has(node.path));
+  const isLoadingChildren = useFileStore((s) => s.loadingDirs.has(node.path));
+  const childEntries = useFileStore((s) => s.dirContents.get(node.path));
   const selectedFile = useFileStore((s) => s.selectedFile);
   const selectFile = useFileStore((s) => s.selectFile);
+  const expandDir = useFileStore((s) => s.expandDir);
+  const collapseDir = useFileStore((s) => s.collapseDir);
+  const showHiddenFiles = useSettingsStore((s) => s.showHiddenFiles);
   const changeKind = useFileStore((s) => s.changedFiles.get(node.path));
   const dirPrefix = node.path + '/';
   const hasChildChanges = useFileStore((s) =>
@@ -320,11 +305,13 @@ function TreeNode({
   );
   const isSelected = selectedFile === node.path;
 
-  const isExpanded = expanded;
-
   const handleClick = (e: React.MouseEvent) => {
     if (node.is_dir) {
-      setExpanded(!expanded);
+      if (isExpanded) {
+        collapseDir(node.path);
+      } else {
+        expandDir(node.path);
+      }
     } else {
       if ((e.ctrlKey || e.metaKey) && useSettingsStore.getState().ctrlClickOpenExternally) {
         bridge.openWithDefaultApp(node.path);
@@ -376,7 +363,7 @@ function TreeNode({
                     .then(() => {
                       const dir = useSettingsStore.getState().workingDirectory
                         || useFileStore.getState().rootPath;
-                      if (dir) useFileStore.getState().refreshTree(dir);
+                      if (dir) useFileStore.getState().refreshDir(dir);
                     })
                     .catch((err: unknown) => console.error('Failed to move file:', err));
                 } else if (!result.droppedInTree) {
@@ -442,7 +429,7 @@ function TreeNode({
             flex-shrink-0" />
         )}
       </button>
-      {node.is_dir && isExpanded && node.children && (
+      {node.is_dir && isExpanded && (
         <div>
           {creatingIn?.dir === node.path && (
             <div className="flex items-center gap-2 py-1 px-2"
@@ -466,24 +453,34 @@ function TreeNode({
               />
             </div>
           )}
-          {node.children.map((child) => (
-            <TreeNode
-              key={child.path}
-              node={child}
-              depth={depth + 1}
-              onContextMenu={onContextMenu}
-              renamingPath={renamingPath}
-              renameValue={renameValue}
-              onRenameChange={onRenameChange}
-              onRenameSubmit={onRenameSubmit}
-              onRenameCancel={onRenameCancel}
-              creatingIn={creatingIn}
-              createName={createName}
-              onCreateNameChange={onCreateNameChange}
-              onCreateSubmit={onCreateSubmit}
-              onCreateCancel={onCreateCancel}
-            />
-          ))}
+          {isLoadingChildren ? (
+            <div className="flex items-center justify-center py-2">
+              <div className="w-4 h-4 border-2 border-accent/30
+                border-t-accent rounded-full animate-spin" />
+            </div>
+          ) : childEntries ? (
+            (() => {
+              const visible = showHiddenFiles ? childEntries : childEntries.filter((n) => !n.name.startsWith('.'));
+              return visible.map((child) => (
+                <TreeNode
+                  key={child.path}
+                  node={child}
+                  depth={depth + 1}
+                  onContextMenu={onContextMenu}
+                  renamingPath={renamingPath}
+                  renameValue={renameValue}
+                  onRenameChange={onRenameChange}
+                  onRenameSubmit={onRenameSubmit}
+                  onRenameCancel={onRenameCancel}
+                  creatingIn={creatingIn}
+                  createName={createName}
+                  onCreateNameChange={onCreateNameChange}
+                  onCreateSubmit={onCreateSubmit}
+                  onCreateCancel={onCreateCancel}
+                />
+              ));
+            })()
+          ) : null}
         </div>
       )}
     </div>
@@ -493,14 +490,14 @@ function TreeNode({
 // --- Main Component ---
 export function FileExplorer() {
   const t = useT();
-  const tree = useFileStore((s) => s.tree);
+  const dirContents = useFileStore((s) => s.dirContents);
   const isLoading = useFileStore((s) => s.isLoading);
   const rootPath = useFileStore((s) => s.rootPath);
   const changedFiles = useFileStore((s) => s.changedFiles);
   const clearChangedFiles = useFileStore((s) => s.clearChangedFiles);
   const workingDirectory = useSettingsStore((s) => s.workingDirectory);
 
-  const refreshTree = useFileStore((s) => s.refreshTree);
+  const refreshDir = useFileStore((s) => s.refreshDir);
   const createFile = useFileStore((s) => s.createFile);
   const createFolder = useFileStore((s) => s.createFolder);
   const isDragOverTree = useFileStore((s) => s.isDragOverTree);
@@ -508,6 +505,8 @@ export function FileExplorer() {
   const toggleHiddenFiles = useSettingsStore((s) => s.toggleHiddenFiles);
 
   const [searchQuery, setSearchQuery] = useState('');
+  const [searchResults, setSearchResults] = useState<FileNode[]>([]);
+  const [isSearching, setIsSearching] = useState(false);
   const [contextMenu, setContextMenu] = useState<ContextMenuState | null>(null);
   const searchRef = useRef<HTMLInputElement>(null);
 
@@ -521,15 +520,30 @@ export function FileExplorer() {
   const [creatingIn, setCreatingIn] = useState<{ dir: string; type: 'file' | 'folder' } | null>(null);
   const [createName, setCreateName] = useState('');
 
-  const filteredTree = useMemo(() => {
-    if (showHiddenFiles) return tree;
-    function filterNodes(nodes: FileNode[]): FileNode[] {
-      return nodes
-        .filter((n) => !n.name.startsWith('.'))
-        .map((n) => n.children ? { ...n, children: filterNodes(n.children) } : n);
+  const rootEntries = useMemo(() => {
+    const entries = dirContents.get(rootPath || '') || [];
+    if (showHiddenFiles) return entries;
+    return entries.filter((n) => !n.name.startsWith('.'));
+  }, [dirContents, rootPath, showHiddenFiles]);
+
+  // Search effect: use Rust search_files for disk-backed search independent of loaded nodes
+  useEffect(() => {
+    if (!searchQuery || !rootPath) {
+      setSearchResults([]);
+      return;
     }
-    return filterNodes(tree);
-  }, [tree, showHiddenFiles]);
+    let cancelled = false;
+    setIsSearching(true);
+    bridge.searchFiles(rootPath, searchQuery).then((results) => {
+      if (!cancelled) {
+        setSearchResults(results);
+        setIsSearching(false);
+      }
+    }).catch(() => {
+      if (!cancelled) setIsSearching(false);
+    });
+    return () => { cancelled = true; };
+  }, [searchQuery, rootPath]);
 
   const changedCount = changedFiles.size;
 
@@ -557,11 +571,11 @@ export function FileExplorer() {
     try {
       await bridge.copyFile(clipboardPath, dest);
       setClipboardPath(null);
-      refreshTree();
+      refreshDir(targetDir);
     } catch {
       // Silently fail
     }
-  }, [clipboardPath, refreshTree]);
+  }, [clipboardPath, refreshDir]);
 
   const handleStartRename = useCallback((path: string) => {
     const name = path.split(/[\\/]/).pop() || '';
@@ -583,11 +597,11 @@ export function FileExplorer() {
     try {
       await bridge.renameFile(renamingPath, dest);
       setRenamingPath(null);
-      refreshTree();
+      refreshDir(dir);
     } catch {
       setRenamingPath(null);
     }
-  }, [renamingPath, renameValue, refreshTree]);
+  }, [renamingPath, renameValue, refreshDir]);
 
   const handleRenameCancel = useCallback(() => {
     setRenamingPath(null);
@@ -601,12 +615,13 @@ export function FileExplorer() {
     if (!deleteTarget) return;
     try {
       await bridge.deleteFile(deleteTarget.path);
+      const parentDir = deleteTarget.path.substring(0, Math.max(deleteTarget.path.lastIndexOf('/'), deleteTarget.path.lastIndexOf('\\')));
       setDeleteTarget(null);
-      refreshTree();
+      refreshDir(parentDir);
     } catch {
       setDeleteTarget(null);
     }
-  }, [deleteTarget, refreshTree]);
+  }, [deleteTarget, refreshDir]);
 
   const handleInsertToChat = useCallback((path: string) => {
     const tabId = useSessionStore.getState().selectedSessionId;
@@ -751,7 +766,7 @@ export function FileExplorer() {
           <button onClick={() => {
               clearChangedFiles();
               const dir = workingDirectory || rootPath;
-              if (dir) refreshTree(dir);
+              if (dir) refreshDir(dir);
             }}
             className="p-1.5 rounded-lg hover:bg-bg-secondary active:bg-bg-tertiary
               text-text-tertiary hover:text-text-secondary transition-smooth"
@@ -813,32 +828,39 @@ export function FileExplorer() {
           </div>
         )}
         <div className="h-full overflow-y-auto py-1">
-        {isLoading && filteredTree.length === 0 ? (
+        {isLoading && rootEntries.length === 0 ? (
           <div className="flex items-center justify-center py-8">
             <div className="w-5 h-5 border-2 border-accent/30
               border-t-accent rounded-full animate-spin" />
           </div>
-        ) : filteredTree.length > 0 ? (
+        ) : rootEntries.length > 0 ? (
           searchQuery ? (
-            // --- Flat search results ---
-            (() => {
-              const matches = collectMatches(filteredTree, searchQuery.toLowerCase(), rootPath || '');
-              return matches.length > 0 ? (
-                <div className="py-1">
-                  {matches.map((m) => (
+            // --- Flat search results (disk-backed via Rust search_files) ---
+            isSearching ? (
+              <div className="flex items-center justify-center py-8">
+                <div className="w-5 h-5 border-2 border-accent/30
+                  border-t-accent rounded-full animate-spin" />
+              </div>
+            ) : searchResults.length > 0 ? (
+              <div className="py-1">
+                {searchResults.map((node) => {
+                  const lastSep = Math.max(node.path.lastIndexOf('/'), node.path.lastIndexOf('\\'));
+                  const parentPath = lastSep > 0 ? node.path.slice(0, lastSep) : '';
+                  const relDir = rootPath ? parentPath.slice(rootPath.length).replace(/^[/\\]/, '') : '';
+                  return (
                     <SearchResultItem
-                      key={m.node.path}
-                      match={m}
+                      key={node.path}
+                      match={{ node, relDir }}
                       onContextMenu={handleContextMenu}
                     />
-                  ))}
-                </div>
-              ) : (
-                <div className="text-center py-8 text-xs text-text-tertiary">
-                  {t('files.noFiles')}
-                </div>
-              );
-            })()
+                  );
+                })}
+              </div>
+            ) : (
+              <div className="text-center py-8 text-xs text-text-tertiary">
+                {t('files.noFiles')}
+              </div>
+            )
           ) : (
             // --- Normal tree view ---
             <>
@@ -866,7 +888,7 @@ export function FileExplorer() {
                   />
                 </div>
               )}
-              {filteredTree.map((node) => (
+              {rootEntries.map((node) => (
                 <TreeNode
                   key={node.path}
                   node={node}

--- a/src/hooks/useFileAttachments.ts
+++ b/src/hooks/useFileAttachments.ts
@@ -269,7 +269,7 @@ export function useFileAttachments() {
                   console.error('Failed to copy file to project:', name, err);
                 }
               }
-              useFileStore.getState().refreshTree(rootPath);
+              useFileStore.getState().refreshDir(rootPath);
             })();
           }
         } else {

--- a/src/hooks/useStreamProcessor.ts
+++ b/src/hooks/useStreamProcessor.ts
@@ -237,7 +237,7 @@ function _scheduleFileTreeRefresh() {
   if (_fileRefreshTimer) return; // already scheduled
   _fileRefreshTimer = setTimeout(() => {
     _fileRefreshTimer = null;
-    useFileStore.getState().refreshTree();
+    useFileStore.getState().refreshDir(useFileStore.getState().rootPath);
   }, 300);
 }
 

--- a/src/lib/tauri-bridge.ts
+++ b/src/lib/tauri-bridge.ts
@@ -354,6 +354,9 @@ export const bridge = {
   readFileTree: (path: string, depth?: number) =>
     invoke<FileNode[]>('read_file_tree', { path, depth }),
 
+  searchFiles: (path: string, query: string) =>
+    invoke<FileNode[]>('search_files', { root: path, query }),
+
   readFileContent: (path: string) =>
     invoke<string>('read_file_content', { path }),
 

--- a/src/stores/fileStore.ts
+++ b/src/stores/fileStore.ts
@@ -9,16 +9,21 @@ const _pendingChanges = new Map<string, FileChangeKind>();
 let _changeFlushRaf = 0;
 
 interface FileState {
-  tree: FileNode[];
+  rootPath: string;
+
+  // Flat directory cache — one entry per navigated-to directory, single level only
+  dirContents: Map<string, FileNode[]>;
+  loadingDirs: Set<string>;
+  expandedDirs: Set<string>;
+
   isLoading: boolean;
   selectedFile: string | null;
   fileContent: string | null;
   isLoadingContent: boolean;
   previewMode: PreviewMode;
-  rootPath: string;
 
   // Editing state
-  editContent: string | null;     // buffer for edits (null = not dirty)
+  editContent: string | null;
   isSaving: boolean;
 
   // Unsaved changes navigation guard
@@ -38,9 +43,14 @@ interface FileState {
   // External drag-drop state
   isDragOverTree: boolean;
 
+  /** Load the root directory (single level). Clears all caches on directory switch. */
   loadTree: (path: string) => Promise<void>;
-  /** Refresh the tree without clearing change markers. Optional path overrides rootPath. */
-  refreshTree: (overridePath?: string) => Promise<void>;
+  /** Fetch a directory's entries and mark it expanded. */
+  expandDir: (path: string) => Promise<void>;
+  /** Mark a directory as collapsed. */
+  collapseDir: (path: string) => void;
+  /** Re-read a single directory level. Only refreshes if the dir is already cached. */
+  refreshDir: (path: string) => Promise<void>;
   selectFile: (path: string) => Promise<void>;
   clearSelection: () => void;
   closePreview: () => void;
@@ -48,7 +58,6 @@ interface FileState {
   setEditContent: (content: string) => void;
   saveFile: () => Promise<void>;
   discardEdits: () => void;
-  setRootPath: (path: string) => void;
   fetchRecentProjects: () => Promise<void>;
   /** Reload the currently previewed file content without toggling selection */
   reloadContent: () => Promise<void>;
@@ -66,13 +75,15 @@ interface FileState {
 }
 
 export const useFileStore = create<FileState>()((set, get) => ({
-  tree: [],
+  rootPath: '',
+  dirContents: new Map(),
+  loadingDirs: new Set(),
+  expandedDirs: new Set(),
   isLoading: false,
   selectedFile: null,
   fileContent: null,
   isLoadingContent: false,
   previewMode: 'preview' as PreviewMode,
-  rootPath: '',
   editContent: null,
   isSaving: false,
   pendingNavigation: null,
@@ -87,18 +98,18 @@ export const useFileStore = create<FileState>()((set, get) => ({
     if (!path) return;
     const prevRoot = get().rootPath;
     const isNewDir = path !== prevRoot;
-    // Always show loading on first load or directory change
     set({
       rootPath: path,
       isLoading: true,
-      // Clear stale tree immediately when switching directories
-      ...(isNewDir ? { tree: [] } : {}),
+      // Clear all caches on directory switch
+      ...(isNewDir ? { dirContents: new Map(), expandedDirs: new Set(), loadingDirs: new Set(), changedFiles: new Map(), directoryMissing: false } : {}),
     });
     try {
-      const tree = await bridge.readFileTree(path, 8);
-      // Guard: only apply if rootPath hasn't changed during async load
+      const entries = await bridge.readFileTree(path, 1);
       if (get().rootPath === path) {
-        set({ tree, isLoading: false, changedFiles: new Map(), directoryMissing: false });
+        const next = new Map(get().dirContents);
+        next.set(path, entries);
+        set({ dirContents: next, isLoading: false, changedFiles: new Map(), directoryMissing: false });
       }
     } catch (err) {
       if (get().rootPath === path) {
@@ -108,21 +119,56 @@ export const useFileStore = create<FileState>()((set, get) => ({
     }
   },
 
-  refreshTree: async (overridePath?: string) => {
-    const dir = overridePath || get().rootPath;
-    if (!dir) return;
+  expandDir: async (path: string) => {
+    const { dirContents, expandedDirs, loadingDirs } = get();
+    const nextExpanded = new Set(expandedDirs);
+    nextExpanded.add(path);
+    set({ expandedDirs: nextExpanded });
+
+    // Already cached — nothing to fetch
+    if (dirContents.has(path)) return;
+
+    // Already loading — avoid duplicate fetch
+    if (loadingDirs.has(path)) return;
+
+    const nextLoading = new Set(loadingDirs);
+    nextLoading.add(path);
+    set({ loadingDirs: nextLoading });
+
     try {
-      const tree = await bridge.readFileTree(dir, 8);
-      // Sync rootPath if override was used and differs
-      if (overridePath && overridePath !== get().rootPath) {
-        set({ tree, rootPath: overridePath });
-      } else {
-        set({ tree });
+      const entries = await bridge.readFileTree(path, 1);
+      const next = new Map(get().dirContents);
+      next.set(path, entries);
+      // Only apply if still expanded (not collapsed during fetch)
+      if (get().expandedDirs.has(path)) {
+        const doneLoading = new Set(get().loadingDirs);
+        doneLoading.delete(path);
+        set({ dirContents: next, loadingDirs: doneLoading });
       }
-    } catch (err) {
-      if (String(err).includes('does not exist')) {
-        set({ directoryMissing: true, tree: [] });
-      }
+    } catch {
+      // Clean up loading state silently
+      const doneLoading = new Set(get().loadingDirs);
+      doneLoading.delete(path);
+      set({ loadingDirs: doneLoading });
+    }
+  },
+
+  collapseDir: (path: string) => {
+    const next = new Set(get().expandedDirs);
+    next.delete(path);
+    set({ expandedDirs: next });
+  },
+
+  refreshDir: async (path: string) => {
+    // Only refresh dirs that are currently expanded
+    if (!get().expandedDirs.has(path)) return;
+    try {
+      const entries = await bridge.readFileTree(path, 1);
+      const next = new Map(get().dirContents);
+      next.set(path, entries);
+      set({ dirContents: next });
+    } catch {
+      // Silently fail — keep previous entries
     }
   },
 
@@ -130,19 +176,16 @@ export const useFileStore = create<FileState>()((set, get) => ({
     const { selectedFile, editContent, fileContent } = get();
     const isDirty = editContent !== null && editContent !== fileContent;
 
-    // If dirty and trying to navigate to a different file, show dialog
     if (isDirty && path !== selectedFile) {
       set({ pendingNavigation: path, showUnsavedDialog: true });
       return;
     }
 
-    // Toggle selection: click again to deselect
     if (selectedFile === path) {
       set({ selectedFile: null, fileContent: null, isLoadingContent: false, editContent: null });
     } else {
       set({ selectedFile: path, fileContent: null, isLoadingContent: true, previewMode: 'preview', editContent: null });
 
-      // Binary-preview files: skip text reading, render with file:// URL in FilePreview
       const ext = path.split('.').pop()?.toLowerCase() || '';
       const BINARY_PREVIEW = new Set([
         'png','jpg','jpeg','gif','webp','bmp','ico',
@@ -151,7 +194,6 @@ export const useFileStore = create<FileState>()((set, get) => ({
       ]);
 
       if (BINARY_PREVIEW.has(ext)) {
-        // Load binary files as base64 data URL for rendering in webview
         try {
           const dataUrl = await bridge.readFileBase64(path);
           if (get().selectedFile === path) {
@@ -165,7 +207,6 @@ export const useFileStore = create<FileState>()((set, get) => ({
       } else {
         try {
           const content = await bridge.readFileContent(path);
-          // Only update if selectedFile hasn't changed during the async call
           if (get().selectedFile === path) {
             set({ fileContent: content, isLoadingContent: false });
           }
@@ -185,7 +226,6 @@ export const useFileStore = create<FileState>()((set, get) => ({
   setPreviewMode: (mode: PreviewMode) => {
     const state = get();
     if (mode === 'edit') {
-      // Entering edit mode: initialize editContent from fileContent
       set({ previewMode: mode, editContent: state.fileContent });
     } else {
       set({ previewMode: mode });
@@ -200,7 +240,6 @@ export const useFileStore = create<FileState>()((set, get) => ({
     set({ isSaving: true });
     try {
       await bridge.writeFileContent(selectedFile, editContent);
-      // Update fileContent to match saved content
       set({ fileContent: editContent, editContent: null, isSaving: false, previewMode: 'preview' });
     } catch {
       set({ isSaving: false });
@@ -210,8 +249,6 @@ export const useFileStore = create<FileState>()((set, get) => ({
   discardEdits: () => {
     set({ editContent: null, previewMode: 'preview' });
   },
-
-  setRootPath: (path: string) => set({ rootPath: path }),
 
   fetchRecentProjects: async () => {
     set({ isLoadingProjects: true });
@@ -226,7 +263,6 @@ export const useFileStore = create<FileState>()((set, get) => ({
   reloadContent: async () => {
     const path = get().selectedFile;
     if (!path) return;
-    // Don't reload while user is editing
     if (get().editContent !== null) return;
     try {
       const ext = path.split('.').pop()?.toLowerCase() || '';
@@ -265,8 +301,6 @@ export const useFileStore = create<FileState>()((set, get) => ({
 
   clearChangedFiles: () => set({ changedFiles: new Map() }),
 
-  // --- Unsaved changes dialog actions ---
-
   confirmDiscard: () => {
     const pending = get().pendingNavigation;
     set({ editContent: null, showUnsavedDialog: false, pendingNavigation: null });
@@ -284,13 +318,11 @@ export const useFileStore = create<FileState>()((set, get) => ({
     set({ pendingNavigation: null, showUnsavedDialog: false });
   },
 
-  // --- New file/folder actions ---
-
   createFile: async (parentDir: string, name: string) => {
     const path = `${parentDir}/${name}`;
     try {
       await bridge.writeFileContent(path, '');
-      await get().refreshTree();
+      await get().refreshDir(parentDir);
       get().selectFile(path);
     } catch {
       // Silently fail
@@ -298,16 +330,13 @@ export const useFileStore = create<FileState>()((set, get) => ({
   },
 
   createFolder: async (parentDir: string, name: string) => {
-    const path = `${parentDir}/${name}`;
     try {
-      await bridge.createDirectory(path);
-      await get().refreshTree();
+      await bridge.createDirectory(`${parentDir}/${name}`);
+      await get().refreshDir(parentDir);
     } catch {
       // Silently fail
     }
   },
-
-  // --- External drag state ---
 
   setDragOverTree: (v: boolean) => set({ isDragOverTree: v }),
 }));


### PR DESCRIPTION
## Summary

This PR replaces the recursive 8-level prefetch file tree with a **flat directory cache** modeled after Windows Explorer architecture. It is a fundamental fix for the CPU 100% issue (#20), going beyond the band-aid approach of skipping file watching on the home directory.

## Problem

The current recursive tree has two structural flaws:
1. **Full-tree prefetch**: `loadTree(path, 8)` reads 8 levels deep in one IPC call, producing tens of thousands of nodes on large directories (home, monorepos)
2. **Whole-tree re-read on every change**: any file creation/deletion triggers `refreshTree()` → full 8-level re-read → replace entire store → re-render whole tree

Result: refresh cost scales with **directory activity**, not with actual change volume. This is the root cause of #20.

## Solution

| Before | After |
|--------|-------|
| `tree: FileNode[]` nested 8 levels deep | `dirContents: Map<path, FileNode[]>` — flat, single-level per directory |
| `loadTree(path, 8)` — 1 IPC, ~10k nodes | `loadTree(path, 1)` — 1 IPC, ~50 entries |
| `refreshTree()` — re-reads everything | `refreshDir(path)` — re-reads only that directory's level |
| File change → full tree re-read | File change → refresh only the expanded parent directory; ignored if not expanded |
| Search: `collectMatches()` walks in-memory tree | `search_files` Rust command — disk-backed, independent of loaded nodes |
| Noisy dirs silently flood IPC | `AppData`/`.cache` filtered from watcher events, but remain browsable in tree |

Architecture: **flat `dirContents` Map + `expandedDirs` Set + on-demand single-level reads**. Each directory expand is a targeted `readFileTree(dir, 1)` call. Only expanded directories react to file watcher events. Unexpanded directories have zero refresh cost.

## Changes

| File | Change |
|------|--------|
| `src-tauri/src/lib.rs` | Add `AppData`/`.cache` to `IGNORED_SEGMENTS`; new `search_files` command |
| `src/lib/tauri-bridge.ts` | Add `searchFiles` bridge method |
| `src/stores/fileStore.ts` | Rewrite: recursive tree → flat cache (`dirContents`, `expandedDirs`, `loadingDirs`, `expandDir`, `collapseDir`, `refreshDir`) |
| `src/components/files/FileExplorer.tsx` | TreeNode uses `expandDir`/`collapseDir` + `dirContents`; search uses `searchFiles`; remove `collectMatches` |
| `src/App.tsx` | `onFileChange` targeted invalidation — only refreshes directories in `expandedDirs` |
| `src/hooks/useStreamProcessor.ts` | `refreshTree()` → `refreshDir(rootPath)` |
| `src/hooks/useFileAttachments.ts` | `refreshTree(rootPath)` → `refreshDir(rootPath)` |

## Design doc

Full rationale and trade-off analysis: https://github.com/cc10143/tokenicode-deepseek-alpha/issues/1

## Tested

- TypeScript: `tsc --noEmit` — clean
- Rust: `cargo check` — clean (only pre-existing warnings)
- Build: `pnpm tauri build` — successful, exe produced and tested on Windows

Closes #20